### PR TITLE
Automatically install packages after copying over hammer.zip

### DIFF
--- a/packages/hammer-cli/package.json
+++ b/packages/hammer-cli/package.json
@@ -31,7 +31,8 @@
     "react": "^16.8.6",
     "require-dir": "^1.2.0",
     "tmp": "^0.1.0",
-    "yargs-parser": "^13.1.1"
+    "yargs-parser": "^13.1.1",
+    "yarn-or-npm": "^3.0.1"
   },
   "devDependencies": {
     "ink-testing-library": "^1.0.2"

--- a/packages/hammer-cli/src/commands/New/New.js
+++ b/packages/hammer-cli/src/commands/New/New.js
@@ -77,13 +77,8 @@ const New = ({ args: [_commandName, targetDir] }) => {
       )
 
       setNewMessage(<Text>Installing packages...</Text>)
-      if (hasYarn()) {
-        spawn.sync(['install', '--cwd', newHammerAppDir], { stdio: 'inherit' })
-      } else {
-        spawn.sync(['install', '--prefix', newHammerAppDir], {
-          stdio: 'inherit',
-        })
-      }
+      const prefixFlag = hasYarn() ? '--cwd' : '--prefix'
+      spawn.sync(['install', prefixFlag, newHammerAppDir], { stdio: 'inherit' })
     }
 
     if (targetDir) {

--- a/packages/hammer-cli/src/commands/New/New.js
+++ b/packages/hammer-cli/src/commands/New/New.js
@@ -3,6 +3,7 @@ import path from 'path'
 import tmp from 'tmp'
 import decompress from 'decompress'
 import axios from 'axios'
+import { spawn, hasYarn } from 'yarn-or-npm'
 
 import React, { useState, useRef, useEffect } from 'react'
 import { Box, Text, Color } from 'ink'
@@ -74,6 +75,15 @@ const New = ({ args: [_commandName, targetDir] }) => {
           Added {files.length} files in <Color green>{newHammerAppDir}</Color>
         </Text>
       )
+
+      setNewMessage(<Text>Installing packages...</Text>)
+      if (hasYarn()) {
+        spawn.sync(['install', '--cwd', newHammerAppDir], { stdio: 'inherit' })
+      } else {
+        spawn.sync(['install', '--prefix', newHammerAppDir], {
+          stdio: 'inherit',
+        })
+      }
     }
 
     if (targetDir) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4278,6 +4278,14 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
+find-up@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
+  integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
+  dependencies:
+    locate-path "^5.0.0"
+    path-exists "^4.0.0"
+
 findup-sync@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-3.0.0.tgz#17b108f9ee512dfb7a5c7f3c8b27ea9e1a9c08d1"
@@ -6037,6 +6045,13 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
+locate-path@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
+  integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
+  dependencies:
+    p-locate "^4.1.0"
+
 lodash._reinterpolate@~3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -6959,6 +6974,13 @@ p-limit@^2.0.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.1.tgz#aa07a788cc3151c939b5131f63570f0dd2009537"
+  integrity sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -6972,6 +6994,13 @@ p-locate@^3.0.0:
   integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
   dependencies:
     p-limit "^2.0.0"
+
+p-locate@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
+  integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
+  dependencies:
+    p-limit "^2.2.0"
 
 p-map-series@^1.0.0:
   version "1.0.0"
@@ -7120,6 +7149,11 @@ path-exists@^3.0.0:
   resolved "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
   integrity sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
 
+path-exists@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
+  integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
+
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
@@ -7230,6 +7264,13 @@ pkg-dir@^3.0.0:
   integrity sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==
   dependencies:
     find-up "^3.0.0"
+
+pkg-dir@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
+  integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
+  dependencies:
+    find-up "^4.0.0"
 
 pkg-up@^2.0.0:
   version "2.0.0"
@@ -9206,6 +9247,14 @@ yargs@^12.0.1, yargs@^12.0.2:
     which-module "^2.0.0"
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
+
+yarn-or-npm@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/yarn-or-npm/-/yarn-or-npm-3.0.1.tgz#6336eea4dff7e23e226acc98c1a8ada17a1b8666"
+  integrity sha512-fTiQP6WbDAh5QZAVdbMQkecZoahnbOjClTQhzv74WX5h2Uaidj1isf9FDes11TKtsZ0/ZVfZsqZ+O3x6aLERHQ==
+  dependencies:
+    cross-spawn "^6.0.5"
+    pkg-dir "^4.2.0"
 
 yauzl@^2.4.2:
   version "2.10.0"


### PR DESCRIPTION
I created a new hammer app and was confused why `yarn dev` wasn't working right away—no packages were installed! 

This PR automatically installs packages using `yarn` or `npm` (whichever is installed on the user's system) after hammer.zip is unzipped in the target directory. The output is piped to the terminal as usual so the user can see what's going on.

One less thing for a newbie to worry about!